### PR TITLE
Port from Source addessing the following issue: Fixed: WOP flood when casting spells using extremely short delays.

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -409,3 +409,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 03-03-2018, Drk84
 - [Port from Source, 03-03-2018, Coruja] Fixed: MOUNT property/function not working correctly.
+
+05-03-2018, Drk84
+- [Port from Source, 30-06-2016, Coruja] Fixed: WOP flood when casting spells using extremely short delays.

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -2981,9 +2981,11 @@ int CChar::Spell_CastStart()
 		WOPColor = Args.m_VarsLocal.GetKeyNum("WOPColor", true);
 		WOPFont = Args.m_VarsLocal.GetKeyNum("WOPFont", true);
 
+		// Correct talk mode for spells WOP is TALKMODE_SPELL, but since sphere doesn't have any delay between spell casts this can allow WOP flood on screen.
+		// So to avoid this problem we must use TALKMODE_SAY, which is not the correct type but with this type the client only show last 3 messages on screen.
 		if ( pSpellDef->m_sRunes[0] == '.' )
 		{
-			Speak((pSpellDef->m_sRunes.GetPtr()) + 1, static_cast<HUE_TYPE>(WOPColor), TALKMODE_SPELL, static_cast<FONT_TYPE>(WOPFont));
+			Speak((pSpellDef->m_sRunes.GetPtr()) + 1, static_cast<HUE_TYPE>(WOPColor), TALKMODE_SAY, static_cast<FONT_TYPE>(WOPFont));
 		}
 		else
 		{
@@ -3001,7 +3003,7 @@ int CChar::Spell_CastStart()
 			if ( len > 0 )
 			{
 				pszTemp[len] = 0;
-				Speak(pszTemp, static_cast<HUE_TYPE>(WOPColor), TALKMODE_SPELL, static_cast<FONT_TYPE>(WOPFont));
+				Speak(pszTemp, static_cast<HUE_TYPE>(WOPColor), TALKMODE_SAY, static_cast<FONT_TYPE>(WOPFont));
 			}
 		}
 	}


### PR DESCRIPTION

Pratically, if you have a macro with Cast Spell, and you start to spam it, the spell Words of Power will flood the screen.

See: https://github.com/Sphereserver/Source/commit/4d6d83a6e24d874bcf82c4d4780a0e0422f632de