### PR TITLE
Fix for criminal command with argument 0

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -510,3 +510,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed: GOLD, NEWGOLD ignoring the ItemsMaxAmount .ini setting.
 - Fixed: duped char not inheriting the brain.
 - Fixed: new characters receiving the newbie sets of starting items for another race.
+
+31-03-2018, Drk84
+-Fixed:  criminal 0 now removing the criminal memory item.

--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -512,4 +512,4 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed: new characters receiving the newbie sets of starting items for another race.
 
 31-03-2018, Drk84
--Fixed:  criminal 0 now removing the criminal memory item.
+-Fixed:  criminal 0 not removing the criminal memory item.

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -3583,8 +3583,13 @@ bool CChar::r_Verb( CScript &s, CTextConsole * pSrc ) // Execute command from sc
 			}
 			break;
 		case CHV_CRIMINAL:
-			if ( s.HasArgs() && ! s.GetArgVal())
-				StatFlag_Clear( STATF_CRIMINAL );
+			if (s.HasArgs() && !s.GetArgVal()) 
+			{
+				StatFlag_Clear(STATF_CRIMINAL);
+				CItem * pMemoryCriminal = LayerFind(LAYER_FLAG_Criminal);
+				if (pMemoryCriminal)
+					pMemoryCriminal->Delete();
+			}
 			else
 				Noto_Criminal();
 			break;


### PR DESCRIPTION
The command "criminal" with  argument 0  only cleared the criminal flag, but didn't remove the criminal memory item, keeping the player in a criminal state until the criminal item was removed or timer expired.