### PR TITLE
Focus Skill 

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -565,3 +565,8 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed: parrying chance didn't scale correctly with Dexterity.
 - [Port from Source, 18-04-2018, Coruja] Changed: Small improvements on tooltip engine (containers weren't resending their tooltip after their weight changed,
     and some tooltips weren't updated for items with an expired timer).
+	
+30-04-2018, Drk84
+- Added behaviour for the Focus skill, the skill is used automatically and only when FEATURE_AOS_UPDATE_B is enabled.
+  The Focus skill increase, passively, the amount of stamina gained by 1 for each 10% points of skill value and increase by 1 the amount of mana gained for 
+  each 20% points of skill value.

--- a/src/game/chars/CCharStat.cpp
+++ b/src/game/chars/CCharStat.cpp
@@ -366,9 +366,9 @@ bool CChar::Stats_Regen(int64 iTimeDiff)
 			mod += 2;		// Humans always have +2 hitpoint regeneration (Tough racial trait)
 
 		/*
-			The Focus skill is used passively and it works automatically only if FEATURES_AOS_UPDATE_B is enabled.
-			The skill increase the amount of stamina gained by 1 for each 10% points of Focus and increase the amount
-			of mana by 1 for each 20%  points of Focus.
+		The Focus skill is used passively and it works automatically only if FEATURES_AOS_UPDATE_B is enabled.
+		The skill increase the amount of stamina gained by 1 for each 10% points of Focus and increase the amount
+		of mana by 1 for each 20%  points of Focus.
 		*/
 		if (g_Cfg.m_iFeatureAOS & FEATURE_AOS_UPDATE_B)
 		{

--- a/src/game/chars/CCharStat.cpp
+++ b/src/game/chars/CCharStat.cpp
@@ -365,6 +365,29 @@ bool CChar::Stats_Regen(int64 iTimeDiff)
 		if ((i == STAT_STR) && (g_Cfg.m_iRacialFlags & RACIALF_HUMAN_TOUGH) && IsHuman())
 			mod += 2;		// Humans always have +2 hitpoint regeneration (Tough racial trait)
 
+		/*
+			The Focus skill is used passively and it works automatically only if FEATURES_AOS_UPDATE_B is enabled.
+			The skill increase the amount of stamina gained by 1 for each 10% points of Focus and increase the amount
+			of mana by 1 for each 20%  points of Focus.
+		*/
+		if (g_Cfg.m_iFeatureAOS & FEATURE_AOS_UPDATE_B)
+		{
+			int iFocusValue = Skill_GetAdjusted(SKILL_FOCUS);
+			switch (i)
+			{
+				case STAT_DEX:
+					mod += (iFocusValue / 100);
+					break;
+				case STAT_INT:
+					mod += (iFocusValue / 200 );
+					break;
+			}
+			/*
+			By using the player skill value as difficulty, the chance to get an increase will be 50% because
+			the bell curva formula is used.
+			*/
+			Skill_Experience(SKILL_FOCUS, iFocusValue);
+		}
 		short StatLimit = Stat_GetMax(i);
 
 		if (IsTrigUsed(TRIGGER_REGENSTAT))


### PR DESCRIPTION
Added behaviour for the Focus skill, the skill is used automatically and only when FEATURE_AOS_UPDATE_B is enabled.
The Focus skill increase, passively, the amount of stamina gained by 1 for each 10% points of skill value and increase by 1 the amount of mana gained for  each 20% points of skill value.