### PR TITLE
Fix for #79: Protection spell AR stacking when COMBAT_ELEMENTAL_ENGIN…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -651,3 +651,6 @@ Added Damageable Items functionality allowing them to have HP bars, only for ite
 To modify their HP use HITS and MAXHITS on them
 [Sphere.ini]
 -Added RegenItemHits to control the update period of those items' hp.
+
+08-05-2018, Drk84
+- Fixed #79: Protection spell AR stacking when COMBAT_ELEMENTAL_ENGINE is disabled. 

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -804,7 +804,7 @@ void CChar::Spell_Effect_Remove(CItem * pSpell)
 			}
 			else
 			{
-				m_defense -= (word)CalcArmorDefense();
+				m_defense = (word)CalcArmorDefense();
 			}
 			if (pClient)
 			{
@@ -1505,7 +1505,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				}
 				else
 				{
-					m_defense += (word)CalcArmorDefense();
+					m_defense = (word)CalcArmorDefense();
 				}
 				if (pClient && IsSetOF(OF_Buffs))
 				{


### PR DESCRIPTION
…E is disabled.

Because the spell items are removed / added before the calculations in CalcArmorDefense() take place, using +=  instead of m_defense = (word)CalcArmorDefense(); allowed to keep the AR spell bonus from the protection spell.