### PR TITLE
quick fix for issue #221, #57 and #219

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1518,8 +1518,8 @@ WARNING: the following change could break some hackish expedient used in scripts
 - Added: Warning message if adding to SKILLMAKE elements which aren't a skill or a typedef.
 - Added: Warning message when trying to craft an item with an invalid SKILLMAKE (instead of just aborting the crafting process without any notification).
 
-13-02-2019, Julian
-- Fixed: dialogclose not removing the dialog from the internal list of dialogs when src is changed through TRYSRC. (Issue #219)
+14-02-2019, Julian
+- Fixed: DIALOGCLOSE not removing the dialog from the internal list of dialogs when src is changed through TRYSRC. (Issue #219)
 - [Port from Source, 29-06-2016, Coruja] Fixed: Attack/Kill command on pets allowing select the pet itself as target, making it attack his owner. (Issue #57)
 - Added: ARGN3 to @MurderMark. If it's set to 1 (or anything but zero), it will skip murder count and criminal flag. (Issue #221)
 		 This will allow users to script their own kill/murder system. Note that Noto_Update() still will be called after the trigger. 

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1517,3 +1517,9 @@ WARNING: the following change could break some hackish expedient used in scripts
 - Fixed: Couldn't make items which didn't have in the SKILLMAKE the typedef for the item needed to craft it.
 - Added: Warning message if adding to SKILLMAKE elements which aren't a skill or a typedef.
 - Added: Warning message when trying to craft an item with an invalid SKILLMAKE (instead of just aborting the crafting process without any notification).
+
+13-02-2019, Julian
+- Fixed: dialogclose not removing the dialog from the internal list of dialogs when src is changed through TRYSRC. (Issue #219)
+- [Port from Source, 29-06-2016, Coruja] Fixed: Attack/Kill command on pets allowing select the pet itself as target, making it attack his owner. (Issue #57)
+- Added: ARGN3 to @MurderMark. If it's set to 1 (or anything but zero), it will skip murder count and criminal flag. (Issue #221)
+		 This will allow users to script their own kill/murder system. Note that Noto_Update() still will be called after the trigger. 

--- a/src/game/CObjBase.cpp
+++ b/src/game/CObjBase.cpp
@@ -2473,8 +2473,7 @@ bool CObjBase::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command fro
 				dword dwRid = g_Cfg.ResourceGetIDType( RES_DIALOG, Arg_ppCmd[0] ).GetPrivateUID();
 				if ( pClientSrc->GetNetState()->isClientKR() )
                     dwRid = g_Cfg.GetKRDialog( dwRid );
-
-				pClientSrc->Dialog_Close( this, dwRid, iQty > 1 ? Exp_GetVal( Arg_ppCmd[1]) : 0 );
+				pClientSrc->Dialog_Close( pClientSrc->GetChar(), dwRid, iQty > 1 ? Exp_GetVal( Arg_ppCmd[1]) : 0 );
 			}
 			break;
 		case OV_TRYP:

--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -438,7 +438,7 @@ bool CChar::NPC_OnHearPetCmdTarg( int iCmd, CChar *pSrc, CObjBase *pObj, const C
 		case PC_ATTACK:
 		case PC_KILL:
 		{
-			if ( !pCharTarg || (pCharTarg == pSrc) )
+			if ( !pCharTarg || pCharTarg == pSrc || pCharTarg == this )
 				break;
 			bSuccess = pCharTarg->OnAttackedBy(pSrc, true);	// we know who told them to do this.
 			if ( bSuccess )

--- a/src/game/chars/CCharNotoriety.cpp
+++ b/src/game/chars/CCharNotoriety.cpp
@@ -554,22 +554,27 @@ void CChar::Noto_Kill(CChar * pKill, int iTotalKillers)
 		if ( !IsPriv(PRIV_GM) )
 		{
 			CScriptTriggerArgs args;
-			args.m_iN1 = m_pPlayer->m_wMurders+1;
+			args.m_iN1 = m_pPlayer->m_wMurders + 1;
 			args.m_iN2 = true;
+			args.m_iN3 = false;
 
 			if ( IsTrigUsed(TRIGGER_MURDERMARK) )
 			{
 				OnTrigger(CTRIG_MurderMark, this, &args);
-				if ( args.m_iN1 < 0 )
+				if (args.m_iN1 < 0)
 					args.m_iN1 = 0;
 			}
 
-			m_pPlayer->m_wMurders = (word)(args.m_iN1);
-			NotoSave_Update();
-			if ( args.m_iN2 )
-				Noto_Criminal();
+			if ( args.m_iN3 < 1 ) 
+			{
+				m_pPlayer->m_wMurders = (word)(args.m_iN1);
+				if (args.m_iN2)
+					Noto_Criminal();
 
-			Noto_Murder();
+				Noto_Murder();
+			}
+
+			NotoSave_Update();
 		}
 	}
 


### PR DESCRIPTION
Issue #221 
Added ARGN3 to @MurderMark which if is set to anything but 0, it will avoid adding the kill and marking the char as criminal/murder. Note that I left out NotoSave_Update(); in case some scripter forgets to use notoupdate after doing their custom checks.