### PR TITLE
Fix for Issue #248 regarding the AMMOANIM, AMMOANIMHUE, AMMOANIMRENDE…

### DIFF
--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -1421,13 +1421,9 @@ void CChar::SoundChar( CRESND_TYPE type )
 		CItem * pWeapon = m_uidWeapon.ItemFind();
 		if ( pWeapon != nullptr )
 		{
-			CVarDefCont * pVar = pWeapon->GetDefKey("AMMOSOUNDHIT", true);
-			if ( pVar )
-			{
-				if ( pVar->GetValNum() )
-					id = (SOUND_TYPE)(pVar->GetValNum());
-			}
-			else
+			//The Weapon_GetSoundHit() method below check if the ranged weapon equipped has the AMMOSOUNDHIT property.
+			id = pWeapon->Weapon_GetSoundHit();
+			if  ( !id )
 			{
 				// weapon type strike noise based on type of weapon and how hard hit.
 				switch ( pWeapon->GetType() )

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1754,7 +1754,7 @@ WAR_SWING_TYPE CChar::Fight_Hit( CChar * pCharTarg )
 
 		SOUND_TYPE iSound = SOUND_NONE;
 		if ( pWeapon )
-			iSound = pWeapon->Weapon_GetSoundMiss();
+			iSound = pWeapon->Weapon_GetSoundMiss(); 
 		if ( iSound == SOUND_NONE)
 		{
 			if ( g_Cfg.IsSkillFlag(skill, SKF_RANGED) )

--- a/src/game/components/CCPropsItemWeaponRanged.cpp
+++ b/src/game/components/CCPropsItemWeaponRanged.cpp
@@ -44,8 +44,12 @@ bool CCPropsItemWeaponRanged::IsPropertyStr(int iPropIndex) const
 {
     switch (iPropIndex)
     {
-        case PROPIWEAPRNG_AMMOTYPE:
-            return true;
+		case PROPIWEAPRNG_AMMOANIM:
+			return true;
+		case PROPIWEAPRNG_AMMOCONT:
+			return true;
+		case PROPIWEAPRNG_AMMOTYPE:
+			return true;
         default:
             return false;
     }

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -4576,7 +4576,7 @@ SKILL_TYPE CItem::Weapon_GetSkill() const
 SOUND_TYPE CItem::Weapon_GetSoundHit() const
 {
 	ADDTOCALLSTACK("CItem::Weapon_GetSoundHit");
-	// Get weapon hit sound
+	// Get ranged weapon ammo hit sound if present.
 
 	word wAmmoSoundHit = GetPropNum(COMP_PROPS_ITEMWEAPONRANGED, PROPIWEAPRNG_AMMOSOUNDHIT, true);
 	if (wAmmoSoundHit > 0)
@@ -4587,7 +4587,7 @@ SOUND_TYPE CItem::Weapon_GetSoundHit() const
 SOUND_TYPE CItem::Weapon_GetSoundMiss() const
 {
 	ADDTOCALLSTACK("CItem::Weapon_GetSoundMiss");
-	// Get weapon miss sound
+	// Get ranged weapon ammo miss sound if present.
 
 	word wAmmoSoundMiss = GetPropNum(COMP_PROPS_ITEMWEAPONRANGED, PROPIWEAPRNG_AMMOSOUNDMISS, true);
 	if ( wAmmoSoundMiss > 0 )
@@ -4659,6 +4659,8 @@ CItem *CItem::Weapon_FindRangedAmmo(CResourceID id)
 		}
 		else // Search container using ITEMID_TYPE
 		{
+			//Reassigned the value from sAmmoCont.GetPtr() because it seems that Exp_GetDWal clears it 
+			ptcAmmoCont = sAmmoCont.GetPtr();
 			CResourceID ridCont(g_Cfg.ResourceGetID(RES_ITEMDEF, ptcAmmoCont));
 			pCont = dynamic_cast<CContainer *>(pParent->ContentFind(ridCont));
 			if (pCont)

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -4651,14 +4651,15 @@ CItem *CItem::Weapon_FindRangedAmmo(CResourceID id)
 	if ( !sAmmoCont.IsEmpty())
 	{
 		// Search container using UID
-		CContainer *pCont = dynamic_cast<CContainer *>(CUID::ItemFind(Exp_GetDWVal(sAmmoCont.GetPtr())));
+		lpctstr  ptcAmmoCont = sAmmoCont.GetPtr();
+		CContainer *pCont = dynamic_cast<CContainer *>(CUID::ItemFind(Exp_GetDWVal(ptcAmmoCont)));
 		if ( pCont )	//If the container exist that means the uid was a valid container uid.
 		{
 			return pCont->ContentFind(id);
 		}
 		else // Search container using ITEMID_TYPE
 		{
-			CResourceID ridCont(g_Cfg.ResourceGetID(RES_ITEMDEF, sAmmoCont.GetPtr()));
+			CResourceID ridCont(g_Cfg.ResourceGetID(RES_ITEMDEF, ptcAmmoCont));
 			pCont = dynamic_cast<CContainer *>(pParent->ContentFind(ridCont));
 			if (pCont)
 				return pCont->ContentFind(id);

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -4651,9 +4651,7 @@ CItem *CItem::Weapon_FindRangedAmmo(CResourceID id)
 	if ( !sAmmoCont.IsEmpty())
 	{
 		// Search container using UID
-		lpctstr  pszAmmoCont = sAmmoCont.GetPtr();
-		CUID uidCont((dword)pszAmmoCont);
-		CContainer *pCont = dynamic_cast<CContainer *>(uidCont.ItemFind());
+		CContainer *pCont = dynamic_cast<CContainer *>(CUID::ItemFind(Exp_GetDWVal(sAmmoCont.GetPtr())));
 		if ( pCont )	//If the container exist that means the uid was a valid container uid.
 		{
 			return pCont->ContentFind(id);


### PR DESCRIPTION
…R, AMMOSOUNDHIT, AMMOSOUNDMISS and AMMOCONT properties.

I also made a fix for  AMMOCONT  but while it seems to work i am not sure if it's the right way, so i have left the old code commented.
The problem i had with AMMOCONT was because it can stores both a numeric value (uid or numeric id) or a string (the string id, ex: i_bag).

Also i have noticed that the Weapon_GetSoundHit/Weapon_GetSoundMiss methods are  called only when used against an archery butte, so AMMOSOUNDHIT and AMMOSHOUNDMISS are used only in this situation.