### PR TITLE
Modified @HitParry to include local.damage (Issue #258)

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1579,5 +1579,5 @@ WARNING: the following change could break some hackish expedient used in scripts
 - Fixed: Criminal status not expiring (Issue #239).
 - Fixed: Chars with MT_SWIM Can flag couldn't walk on static water tiles (Issue #253), and chars without MT_SWIM could walk over dynamic water tiles.
 
-18-03-2019, Julian
+24-03-2019, Julian
 - Modified: @HitParry to include local.Damage, which contains the raw amount of damage before any parrying modification.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1578,3 +1578,6 @@ WARNING: the following change could break some hackish expedient used in scripts
 17-03-2019, Nolok
 - Fixed: Criminal status not expiring (Issue #239).
 - Fixed: Chars with MT_SWIM Can flag couldn't walk on static water tiles (Issue #253), and chars without MT_SWIM could walk over dynamic water tiles.
+
+18-03-2019, Julian
+- Modified: @HitParry to include local.Damage, which contains the raw amount of damage before any parrying modification.


### PR DESCRIPTION
As a reference to raw damage before applying parrying reduction. I just moved iDmg to the section before parrying to a local can be created. That way user can modify the percent with ARGN1 or make custom calculations and apply parrying reduction to local.damage directly.

This is to resolve Issue #258 