### PR TITLE
Fixes for ContextMenu and dynamic gump lines.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1582,7 +1582,7 @@ WARNING: the following change could break some hackish expedient used in scripts
 24-03-2019, Julian
 - Modified: @HitParry to include local.Damage, which contains the raw amount of damage before any parrying modification.
 
-31-03-2018, Nolok
+31-03-2019, Nolok
 - Fixed: Swimming NPCs could pass under items even if their z wasn't high enough.
 - Fixed: NPCs could always walk inside places with a ceiling too low for them to fit below.
 - Fixed: The absence of MT_WALK didn't stop NPCs from walking on land.
@@ -1590,7 +1590,7 @@ WARNING: the following change could break some hackish expedient used in scripts
 - Fixed: BTFish encryption not working (Issue #256).
 - Fixed: During character creation, invalid professions sent by the client will now be ignored.
 
-05-04-2018, Nolok
+05-04-2019, Nolok
 - Added: trigger @CreateLoot. It fires when the NPC dies, if it is allowed to have a loot (not a player, not conjured, no DEATHF_NOLOOT).
 	The main advantage of using this trigger in place of @NPCRestock and @Create is that items will be created only when they are required,
 	so that a big number "useless" items won't be stored in the save files (= smaller save files), also GMs wouldn't be able to see what a monster is going to drop before it dies.
@@ -1599,17 +1599,22 @@ WARNING: the following change could break some hackish expedient used in scripts
 - Fixed: Items created with NEWLOOT didn't store the script file and line number where they were created, so that info wasn't eventually shown by garbage collection.
 - Fixed: NPCs able to spawn to a P they cannot move at/from (Issue #255).
 
-06-04-2018, Nolok
+06-04-2019, Nolok
 - Fixed: MT_NOINDOORS CAN flag didn't prevent a char to walk under a roof (or items acting as such, like ones with the "platform" or "blocking" tiledata flag).
 - Added: MT_NOBLOCKHEIGHT CAN flag (020000) to ignore char's height when checking if it can move to a point (otherwise, if the ceiling is too low for it to fit below, the movement is blocked).
 
-07-04-2018, Nolok
+07-04-2019, Nolok
 - Added: REGION_FLAG_NOMINING (020000) to prevent mining in a region.
 - Added: REGION_FLAG_WALK_NOBLOCKHEIGHT (040000) to ignore char height for walkchecks inside the region (see MT_NOBLOCKHEIGHT). Use with caution!
 - Fixed: MORE value wasn't saved correctly if the value was a defname.
 - Fixed: When retrieving MORE value, the numeric value was always returned even if it should have been a defname. Retrieving MORE1 didn't have this problem.
 
-08-04-2018, Nolok
+08-04-2019, Nolok
 - Changed: NEWGOLD now accepts a second argument: if it's 1, the new gold is stacked on the existing pile in the pack, otherwise it's stacked in a new pile like it has always been (Issue #246).
 	Usage: NEWGOLD amount, pile(1/0)
 - Fixed: MORE2 value wasn't saved correctly if the value was a defname. Also, retrieving its value always returned a number even if it should have been a defname.
+
+10-04-2019, Julian
+- Fixed: Feature sending to unencrypted clients (mostly with Razor) using ReportedCliver as reference instead of CliVer.
+- Fixed: Text index for dynamic dialog lines, such as dhtmlgump, they were starting at random ranges instead of starting at 0.
+- Modified: Hardcoded the train and tame function for Context Menu (or Popup Menu), this way you can remove e_Trainer from every NPC.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1614,7 +1614,7 @@ WARNING: the following change could break some hackish expedient used in scripts
 	Usage: NEWGOLD amount, pile(1/0)
 - Fixed: MORE2 value wasn't saved correctly if the value was a defname. Also, retrieving its value always returned a number even if it should have been a defname.
 
-10-04-2019, Julian
+12-04-2019, Julian
 - Fixed: Feature sending to unencrypted clients (mostly with Razor) using ReportedCliver as reference instead of CliVer.
 - Fixed: Text index for dynamic dialog lines, such as dhtmlgump, they were starting at random ranges instead of starting at 0.
 - Modified: Hardcoded the train and tame function for Context Menu (or Popup Menu), this way you can remove e_Trainer from every NPC.

--- a/src/common/resource/blocks/CDialogDef.cpp
+++ b/src/common/resource/blocks/CDialogDef.cpp
@@ -275,8 +275,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
                 if ( *pszArgs == '.' )			pszArgs++;
 
-            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "text %d %d %d %" PRIuSIZE_T, x, y, hue, iText );
+            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "text %d %d %d %d", x, y, hue, iText );
             ++m_uiControls;
             return true;
         }
@@ -295,8 +295,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
                 if ( *pszArgs == '.' )			pszArgs++;
 
-            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "croppedtext %d %d %d %d %d %" PRIuSIZE_T, x, y, w, h, hue, iText );
+            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "croppedtext %d %d %d %d %d %d", x, y, w, h, hue, iText );
             ++m_uiControls;
             return true;
         }
@@ -315,8 +315,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( options );
             SKIP_ALL( pszArgs )
 
-                uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "htmlgump %d %d %d %d %" PRIuSIZE_T " %d %d", x, y, w, h, iText, bck, options );
+            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "htmlgump %d %d %d %d %d %d %d", x, y, w, h, iText, bck, options );
             ++m_uiControls;
             return true;
         }
@@ -335,8 +335,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( id );
             SKIP_ALL( pszArgs )
 
-                uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "textentry %d %d %d %d %d %d %" PRIuSIZE_T, x, y, w, h, hue, id, iText );
+            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "textentry %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText );
             ++m_uiControls;
             return true;
         }
@@ -356,8 +356,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( charLimit );
             SKIP_ALL( pszArgs )
 
-                uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "textentrylimited %d %d %d %d %d %d %" PRIuSIZE_T " %d", x, y, w, h, hue, id, iText, charLimit );
+            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "textentrylimited %d %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText, charLimit );
             ++m_uiControls;
             return true;
         }

--- a/src/common/resource/blocks/CDialogDef.cpp
+++ b/src/common/resource/blocks/CDialogDef.cpp
@@ -275,7 +275,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
                 if ( *pszArgs == '.' )			pszArgs++;
 
-            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
             m_sControls[m_uiControls].Format( "text %d %d %d %d", x, y, hue, iText );
             ++m_uiControls;
             return true;
@@ -295,7 +295,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
                 if ( *pszArgs == '.' )			pszArgs++;
 
-            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
             m_sControls[m_uiControls].Format( "croppedtext %d %d %d %d %d %d", x, y, w, h, hue, iText );
             ++m_uiControls;
             return true;
@@ -315,7 +315,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( options );
             SKIP_ALL( pszArgs )
 
-            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
             m_sControls[m_uiControls].Format( "htmlgump %d %d %d %d %d %d %d", x, y, w, h, iText, bck, options );
             ++m_uiControls;
             return true;
@@ -335,7 +335,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( id );
             SKIP_ALL( pszArgs )
 
-            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
             m_sControls[m_uiControls].Format( "textentry %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText );
             ++m_uiControls;
             return true;
@@ -356,7 +356,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             GET_ABSOLUTE( charLimit );
             SKIP_ALL( pszArgs )
 
-            int iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
             m_sControls[m_uiControls].Format( "textentrylimited %d %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText, charLimit );
             ++m_uiControls;
             return true;

--- a/src/common/resource/blocks/CDialogDef.cpp
+++ b/src/common/resource/blocks/CDialogDef.cpp
@@ -276,7 +276,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
                 if ( *pszArgs == '.' )			pszArgs++;
 
             uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "text %d %d %d %d", x, y, hue, iText );
+            m_sControls[m_uiControls].Format( "text %d %d %d %u", x, y, hue, iText );
             ++m_uiControls;
             return true;
         }
@@ -295,8 +295,8 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
                 if ( *pszArgs == '.' )			pszArgs++;
 
-            uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "croppedtext %d %d %d %d %d %d", x, y, w, h, hue, iText );
+			uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
+            m_sControls[m_uiControls].Format( "croppedtext %d %d %d %d %d %u", x, y, w, h, hue, iText );
             ++m_uiControls;
             return true;
         }
@@ -316,7 +316,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
 
             uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "htmlgump %d %d %d %d %d %d %d", x, y, w, h, iText, bck, options );
+            m_sControls[m_uiControls].Format( "htmlgump %d %d %d %d %u %d %d", x, y, w, h, iText, bck, options );
             ++m_uiControls;
             return true;
         }
@@ -336,7 +336,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
 
             uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "textentry %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText );
+            m_sControls[m_uiControls].Format( "textentry %d %d %d %d %d %d %u", x, y, w, h, hue, id, iText );
             ++m_uiControls;
             return true;
         }
@@ -357,7 +357,7 @@ bool CDialogDef::r_Verb( CScript & s, CTextConsole * pSrc )	// some command on t
             SKIP_ALL( pszArgs )
 
             uint iText = GumpAddText( *pszArgs ? pszArgs : "" );
-            m_sControls[m_uiControls].Format( "textentrylimited %d %d %d %d %d %d %d %d", x, y, w, h, hue, id, iText, charLimit );
+            m_sControls[m_uiControls].Format( "textentrylimited %d %d %d %d %d %d %u %d", x, y, w, h, hue, id, iText, charLimit );
             ++m_uiControls;
             return true;
         }

--- a/src/game/clients/CClient.h
+++ b/src/game/clients/CClient.h
@@ -588,6 +588,7 @@ private:
 #define POPUP_PETRELEASE 50
 #define POPUP_STABLESTABLE 51
 #define POPUP_STABLERETRIEVE 52
+#define POPUP_TAME 53
 #define POPUP_TRAINSKILL 100
 
 	PacketDisplayPopup* m_pPopupPacket;

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -1340,7 +1340,7 @@ void CClient::Event_VendorSell(CChar* pVendor, const VendorItem* items, uint uiI
 	int iGold = 0;
 	bool fShortfall = false;
 
-	for (uint i = 0; i < uiItemCount; i)
+	for (uint i = 0; i < uiItemCount; i++)
 	{
 		CItemVendable * pItem = dynamic_cast <CItemVendable *> (items[i].m_serial.ItemFind());
 		if ( pItem == nullptr || pItem->IsValidSaleItem(true) == false )
@@ -2365,7 +2365,6 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 				m_pPopupPacket->addOption(POPUP_VENDORBUY, 6103, POPUPFLAG_COLOR, 0xFFFF);
 				m_pPopupPacket->addOption(POPUP_VENDORSELL, 6104, POPUPFLAG_COLOR, 0xFFFF);
 
-				WORD wFlag, wSkillNPC, wSkillPlayer;
 				for (unsigned int i = 0; i < g_Cfg.m_iMaxSkill; ++i)
 				{
 					if (!g_Cfg.m_SkillIndexDefs.IsValidIndex(i))
@@ -2373,13 +2372,13 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 					if (i == SKILL_SPELLWEAVING)
 						continue;
 
-					wSkillNPC = pChar->Skill_GetBase(static_cast<SKILL_TYPE>(i));
+					ushort wSkillNPC = pChar->Skill_GetBase( (SKILL_TYPE)i );
 					if (wSkillNPC < 300)
 						continue;
 
-					wSkillPlayer = m_pChar->Skill_GetBase(static_cast<SKILL_TYPE>(i));
-					wFlag = ((wSkillPlayer >= g_Cfg.m_iTrainSkillMax) || (wSkillPlayer >= (wSkillNPC * g_Cfg.m_iTrainSkillPercent) / 100)) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
-					m_pPopupPacket->addOption(static_cast<WORD>(POPUP_TRAINSKILL + i), 6000 + i, wFlag, 0xFFFF);
+					ushort wSkillPlayer = m_pChar->Skill_GetBase( (SKILL_TYPE)i );
+					word wFlag = ((wSkillPlayer >= g_Cfg.m_iTrainSkillMax) || (wSkillPlayer >= (wSkillNPC * g_Cfg.m_iTrainSkillPercent) / 100)) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
+					m_pPopupPacket->addOption( (word)(POPUP_TRAINSKILL + i), 6000 + i, wFlag, 0xFFFF);
 				}
 
 				if (pChar->m_pNPC->m_Brain == NPCBRAIN_STABLE)
@@ -2591,8 +2590,8 @@ void CClient::Event_AOSPopupMenuSelect(dword uid, word EntryTag)	//do something 
 
 		if ((EntryTag >= POPUP_TRAINSKILL) && (EntryTag < POPUP_TRAINSKILL + g_Cfg.m_iMaxSkill))
 		{
-			TCHAR *pszMsg = Str_GetTemp();
-			SKILL_TYPE iSkill = static_cast<SKILL_TYPE>(EntryTag - POPUP_TRAINSKILL);
+			tchar * pszMsg = Str_GetTemp();
+			SKILL_TYPE iSkill = (SKILL_TYPE)(EntryTag - POPUP_TRAINSKILL);
 			sprintf(pszMsg, "train %s", g_Cfg.GetSkillKey(iSkill));
 			pChar->NPC_OnHear(pszMsg, m_pChar);
 			return;

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -2352,61 +2352,88 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 	if ( pChar && !fPreparePacket )
 	{
 
-		if ( pChar->IsPlayableCharacter() )
+		if (pChar->IsPlayableCharacter())
 			m_pPopupPacket->addOption(POPUP_PAPERDOLL, 6123, POPUPFLAG_COLOR, 0xFFFF);
 
-		if ( pChar->m_pNPC )
+		if (pChar->m_pNPC)
 		{
-			if ( pChar->m_pNPC->m_Brain == NPCBRAIN_BANKER )
-				m_pPopupPacket->addOption(POPUP_BANKBOX, 6105, POPUPFLAG_COLOR, 0xFFFF);
-			else if ( pChar->m_pNPC->m_Brain == NPCBRAIN_STABLE )
+			if (pChar->NPC_IsVendor())
 			{
-				m_pPopupPacket->addOption(POPUP_STABLESTABLE, 6126, POPUPFLAG_COLOR, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_STABLERETRIEVE, 6127, POPUPFLAG_COLOR, 0xFFFF);
-			}
+				if (pChar->m_pNPC->m_Brain == NPCBRAIN_BANKER)
+					m_pPopupPacket->addOption(POPUP_BANKBOX, 6105, POPUPFLAG_COLOR, 0xFFFF);
 
-			if ( pChar->NPC_IsVendor() )
-			{
 				m_pPopupPacket->addOption(POPUP_VENDORBUY, 6103, POPUPFLAG_COLOR, 0xFFFF);
 				m_pPopupPacket->addOption(POPUP_VENDORSELL, 6104, POPUPFLAG_COLOR, 0xFFFF);
-			}
 
-			word iEnabled = pChar->IsStatFlag(STATF_DEAD) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
-			if ( pChar->IsOwnedBy(m_pChar, false) )
-			{
-				CREID_TYPE id = pChar->GetID();
-				bool bBackpack = (id == CREID_LLAMA_PACK || id == CREID_HORSE_PACK || id == CREID_GIANT_BEETLE);
-
-				m_pPopupPacket->addOption(POPUP_PETGUARD, 6107, iEnabled, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETFOLLOW, 6108, POPUPFLAG_COLOR, 0xFFFF);
-				if ( bBackpack )
-					m_pPopupPacket->addOption(POPUP_PETDROP, 6109, iEnabled, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETKILL, 6111, iEnabled, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETSTOP, 6112, POPUPFLAG_COLOR, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETSTAY, 6114, POPUPFLAG_COLOR, 0xFFFF);
-				if ( !pChar->IsStatFlag(STATF_CONJURED) )
+				WORD wFlag, wSkillNPC, wSkillPlayer;
+				for (unsigned int i = 0; i < g_Cfg.m_iMaxSkill; ++i)
 				{
-					m_pPopupPacket->addOption(POPUP_PETFRIEND_ADD, 6110, iEnabled, 0xFFFF);
-					m_pPopupPacket->addOption(POPUP_PETFRIEND_REMOVE, 6099, iEnabled, 0xFFFF);
-					m_pPopupPacket->addOption(POPUP_PETTRANSFER, 6113, POPUPFLAG_COLOR, 0xFFFF);
+					if (!g_Cfg.m_SkillIndexDefs.IsValidIndex(i))
+						continue;
+					if (i == SKILL_SPELLWEAVING)
+						continue;
+
+					wSkillNPC = pChar->Skill_GetBase(static_cast<SKILL_TYPE>(i));
+					if (wSkillNPC < 300)
+						continue;
+
+					wSkillPlayer = m_pChar->Skill_GetBase(static_cast<SKILL_TYPE>(i));
+					wFlag = ((wSkillPlayer >= g_Cfg.m_iTrainSkillMax) || (wSkillPlayer >= (wSkillNPC * g_Cfg.m_iTrainSkillPercent) / 100)) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
+					m_pPopupPacket->addOption(static_cast<WORD>(POPUP_TRAINSKILL + i), 6000 + i, wFlag, 0xFFFF);
 				}
-				m_pPopupPacket->addOption(POPUP_PETRELEASE, 6118, POPUPFLAG_COLOR, 0xFFFF);
-				if ( bBackpack )
-					m_pPopupPacket->addOption(POPUP_BACKPACK, 6145, iEnabled, 0xFFFF);
+
+				if (pChar->m_pNPC->m_Brain == NPCBRAIN_STABLE)
+				{
+					m_pPopupPacket->addOption(POPUP_STABLESTABLE, 6126, POPUPFLAG_COLOR, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_STABLERETRIEVE, 6127, POPUPFLAG_COLOR, 0xFFFF);
+				}
 			}
-			else if ( pChar->Memory_FindObjTypes(m_pChar, MEMORY_FRIEND) )
+			else
 			{
-				m_pPopupPacket->addOption(POPUP_PETFOLLOW, 6108, iEnabled, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETSTOP, 6112, iEnabled, 0xFFFF);
-				m_pPopupPacket->addOption(POPUP_PETSTAY, 6114, iEnabled, 0xFFFF);
+				word iEnabled = pChar->IsStatFlag(STATF_DEAD) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
+				if ((pChar->IsOwnedBy(m_pChar, false)) && (pChar->m_pNPC->m_Brain != NPCBRAIN_BERSERK))
+				{
+					CREID_TYPE id = pChar->GetID();
+
+					m_pPopupPacket->addOption(POPUP_PETGUARD, 6107, iEnabled, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_PETFOLLOW, 6108, POPUPFLAG_COLOR, 0xFFFF);
+
+					bool bBackpack = (id == CREID_LLAMA_PACK || id == CREID_HORSE_PACK || id == CREID_GIANT_BEETLE);
+					if (bBackpack)
+						m_pPopupPacket->addOption(POPUP_PETDROP, 6109, iEnabled, 0xFFFF);
+
+					m_pPopupPacket->addOption(POPUP_PETKILL, 6111, iEnabled, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_PETSTOP, 6112, POPUPFLAG_COLOR, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_PETSTAY, 6114, POPUPFLAG_COLOR, 0xFFFF);
+
+					if (!pChar->IsStatFlag(STATF_CONJURED))
+					{
+						m_pPopupPacket->addOption(POPUP_PETFRIEND_ADD, 6110, iEnabled, 0xFFFF);
+						m_pPopupPacket->addOption(POPUP_PETFRIEND_REMOVE, 6099, iEnabled, 0xFFFF);
+						m_pPopupPacket->addOption(POPUP_PETTRANSFER, 6113, POPUPFLAG_COLOR, 0xFFFF);
+					}
+
+					m_pPopupPacket->addOption(POPUP_PETRELEASE, 6118, POPUPFLAG_COLOR, 0xFFFF);
+
+					if (bBackpack)
+						m_pPopupPacket->addOption(POPUP_BACKPACK, 6145, iEnabled, 0xFFFF);
+				}
+				else if (pChar->Memory_FindObjTypes(m_pChar, MEMORY_FRIEND))
+				{
+					m_pPopupPacket->addOption(POPUP_PETFOLLOW, 6108, iEnabled, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_PETSTOP, 6112, iEnabled, 0xFFFF);
+					m_pPopupPacket->addOption(POPUP_PETSTAY, 6114, iEnabled, 0xFFFF);
+				}
+				else if (!pChar->IsStatFlag(STATF_PET) && (pChar->Skill_GetBase(SKILL_TAMING) > 0))
+					m_pPopupPacket->addOption(POPUP_TAME, 6130, POPUPFLAG_COLOR, 0xFFFF);
 			}
 		}
-		else if ( pChar == m_pChar )
+		else if (pChar == m_pChar)
 		{
 			m_pPopupPacket->addOption(POPUP_BACKPACK, 6145, POPUPFLAG_COLOR, 0xFFFF);
-			if ( GetNetState()->isClientVersion(MINCLIVER_STATUS_V6) )
+			if (GetNetState()->isClientVersion(MINCLIVER_STATUS_V6))
 			{
-				if ( pChar->GetDefNum("REFUSETRADES", true) )
+				if (pChar->GetDefNum("REFUSETRADES", true))
 					m_pPopupPacket->addOption(POPUP_TRADE_ALLOW, 1154112, POPUPFLAG_COLOR, 0xFFFF);
 				else
 					m_pPopupPacket->addOption(POPUP_TRADE_REFUSE, 1154113, POPUPFLAG_COLOR, 0xFFFF);
@@ -2414,17 +2441,17 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 		}
 		else
 		{
-			if ( m_pChar->m_pParty == nullptr && pChar->m_pParty == nullptr )
+			if (m_pChar->m_pParty == nullptr && pChar->m_pParty == nullptr)
 				m_pPopupPacket->addOption(POPUP_PARTY_ADD, 197, POPUPFLAG_COLOR, 0xFFFF);
-			else if ( m_pChar->m_pParty != nullptr && m_pChar->m_pParty->IsPartyMaster(m_pChar) )
+			else if (m_pChar->m_pParty != nullptr && m_pChar->m_pParty->IsPartyMaster(m_pChar))
 			{
-				if ( m_pChar->m_pParty == nullptr )
+				if (m_pChar->m_pParty == nullptr)
 					m_pPopupPacket->addOption(POPUP_PARTY_ADD, 197, POPUPFLAG_COLOR, 0xFFFF);
-				else if ( pChar->m_pParty == m_pChar->m_pParty )
+				else if (pChar->m_pParty == m_pChar->m_pParty)
 					m_pPopupPacket->addOption(POPUP_PARTY_REMOVE, 198, POPUPFLAG_COLOR, 0xFFFF);
 			}
 
-			if ( GetNetState()->isClientVersion(MINCLIVER_TOL) && m_pChar->GetDist(pChar) <= 2 )
+			if (GetNetState()->isClientVersion(MINCLIVER_TOL) && m_pChar->GetDist(pChar) <= 2)
 				m_pPopupPacket->addOption(POPUP_TRADE_OPEN, 1077728, POPUPFLAG_COLOR, 0xFFFF);
 		}
 
@@ -2551,6 +2578,24 @@ void CClient::Event_AOSPopupMenuSelect(dword uid, word EntryTag)	//do something 
 				if ( pChar->m_pNPC->m_Brain == NPCBRAIN_STABLE )
 					pChar->NPC_OnHear("retrieve", m_pChar);
 				break;
+
+			case POPUP_TAME:
+				if (m_pChar->Skill_CanUse(SKILL_TAMING) && !m_pChar->Skill_Wait(SKILL_TAMING))
+				{
+					m_pChar->m_Act_UID = pChar->GetUID();
+					m_pChar->Skill_Start(SKILL_TAMING);
+				}
+				return;
+
+		}
+
+		if ((EntryTag >= POPUP_TRAINSKILL) && (EntryTag < POPUP_TRAINSKILL + g_Cfg.m_iMaxSkill))
+		{
+			TCHAR *pszMsg = Str_GetTemp();
+			SKILL_TYPE iSkill = static_cast<SKILL_TYPE>(EntryTag - POPUP_TRAINSKILL);
+			sprintf(pszMsg, "train %s", g_Cfg.GetSkillKey(iSkill));
+			pChar->NPC_OnHear(pszMsg, m_pChar);
+			return;
 		}
 	}
 

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -3354,7 +3354,7 @@ PacketCharacterList::PacketCharacterList(CClient* target) : PacketSend(XCMD_Char
 		}
 	}
 
-    if (tmVer > 1260000)
+    if (tmVerReported > 1260000)
     {
         dword flags = g_Cfg.GetPacketFlag(true, (RESDISPLAY_VERSION)(account->GetResDisp()),
             maximum(account->GetMaxChars(), (byte)(account->m_Chars.GetCharCount())));


### PR DESCRIPTION
Okay, so this is the revision (by the way, you forgot to switch years haha)

```
- Fixed: Feature sending to unencrypted clients (mostly with Razor) using ReportedCliver as reference instead of CliVer.
- Fixed: Text index for dynamic dialog lines, such as dhtmlgump, they were starting at random ranges instead of starting at 0.
- Modified: Hardcoded the train and tame function for Context Menu (or Popup Menu), this way you can remove e_Trainer from every NPC.
```

First entry: When connecting with razor seems that tmVer is 0 at PacketCharacterList, so FeatureFlags are gonna be according to client 0. Instead, I used the reported cliver which is tmVerReported. I can see the client version on that variable and the server will send the correct feature flags.

Second entry: I don't know if that is the best solution, the index was starting at 1400000 or some weird number when using uint. In the default client this works fine, but when using ClassicUO, the client crashed since it was expecting and index from 0~amount of text. Anyway, switching to int and using %d as argument fixed it.

Third entry: Some commit I took from 56, can't find when, but the default script pack isn't using e_trainer anymore and if someone wants to use that script pack and this sphere version, they won't have any train button on the Context Menu.