### PR TITLE
Fix for ammo not being consumed if the player misses his target.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1751,3 +1751,6 @@ WARNING: Important change!
 - Added: .ini experimental flag EF_WalkCheckHeightMounted. When this is on, assume during walkchecks that a mounted character is taller by 4 z points. Since the client walkcheck considers the height of a mounted char to be
 	the same as the height of the unmounted char, enabling this might prevent mounted characters to walk under places they could before.
 - Fixed: NPCs with MT_FLY could fly over a wall and then drop through the roof, falling inside a building they shouldn't be able to enter in that way.
+
+04-06-2019, Drk84
+- Fixed: Arrow not being consumed in @Hitmiss.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1769,10 +1769,15 @@ WAR_SWING_TYPE CChar::Fight_Hit( CChar * pCharTarg )
 				pAmmo = nullptr;
 		}
 
-		if ( pAmmo && m_pPlayer && (40 >= Calc_GetRandVal(100)) )
+		if ( pAmmo && m_pPlayer  )
 		{
-			pAmmo->UnStackSplit(1);
-			pAmmo->MoveToDecay(pCharTarg->GetTopPoint(), g_Cfg.m_iDecay_Item);
+			if (40 >= Calc_GetRandVal(100))
+			{
+				pAmmo->UnStackSplit(1);
+				pAmmo->MoveToDecay(pCharTarg->GetTopPoint(), g_Cfg.m_iDecay_Item);
+			}
+			else
+				pAmmo->ConsumeAmount(1);
 		}
 
 		if ( IsPriv(PRIV_DETAIL) )


### PR DESCRIPTION
There was only a 40% chance that the arrow was moved at the feet of the target otherwise the arrow would not be removed.

Instead, if the character hits the target the ammo is consumed correctly.