### PR TITLE
Added: Two optional parameters "linearcheck" and "forcecheck" to the …

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1788,3 +1788,36 @@ WARNING: Important change!
 - Fixed: Profiler and worldsave message showing incorrect times (Issue #296).
 - Fixed: Client listing showing the number of the online clients at the end of the list, instead of the top.
 - Added: Doc file "Porting from 0.55 to 0.56.txt" (the content was posted years ago by XuN on the forum).
+
+22-07-2019, Drk84
+- Added: Two optional parameters "linearcheck" and "forcecheck" to the SKILLUSEQUICK character command:
+	SKILLUSEQUICK "skillId", "difficulty", "linearcheck", "forcecheck"
+	
+	Linearcheck:
+	This optional parameter when set to 1 will make Sphere performs a linear check instead of using the default Bell Curve formula.
+	The linear check is usually used for combat checks (hitting, parrying, resisting spells) while the Bell curve check is usually used by almost all of the other skills.
+	Take note that when using the linear check, the highest is the difficulty value the easier is to pass the test, while the opposite is true for a Bell curve check. 
+	
+	Forcecheck:
+	This optional paramter allows the execution of the Skill_UseQuick method by a skill with SKF_SCRIPTED flag.
+	By default Sphere does not allow a skill with SKF_SCRIPTED flag to execute the Skill_UseQuick method, setting the value to 1 will allow the execution
+	of the Skill_UseQuick method.
+		
+	Examples:
+	skillusequick skill_appraise,75			//Make a quick check with item id skill with a difficulty of 75 and using the bell formula.
+	skillusequick skill_appraise,<itemid>/10,1		//Make a quick check with the item id skill with a difficulty equal to the character itemid value and using the linear check formula.
+	skillusequick skill_parrying,50,0,1		//Assuming that the parrying skill has the SKF_SCRIPTED flag, make a quick check with parrying skill,  using the Bell curve formula with a difficulty of 50 and forcing the execution of  the Skill_UseQuick method.
+	
+	Special Cases
+	Sphere internally uses a quick check when certain actions are performed:
+	
+	Camping: Camping skill uses a quick check for activating up campfires.
+	Mining:  Lingot smelting is handled by a quick check.
+	Musicianship: Playing an instrument is handled by a quick check.
+	Parrying: The success check for Parrying is handled by a quick check, remember that by adding the SKF_SCRIPTED flags to the Parrying skill will made you lose access to the @HitParry trigger.
+	Repairing Items: Two quick checks are made, one uses the crafting skill from which the item is created by, the second uses the Arms Lore skill.
+	Resisting Spells: A quick check is made when resisting a spell with SPELLFLAG_RESIST.
+	Tinkering: Copying a key is performed by a Tinkering quick check.
+	Training Dummies: All the Melee, Ranged and Pickpocket dummies uses a quick check.
+	Tracking: Tracking uses a quick check when STARTING to track (the tracking menu is displayed and the quarry category is selected).
+	

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -2498,15 +2498,15 @@ do_default:
 
 				if ( *ptcKey )
 				{
-					tchar * ppArgs[2];
+					tchar * ppArgs[4];
 					int iQty = Str_ParseCmds(const_cast<tchar *>(ptcKey), ppArgs, CountOf( ppArgs ));
-					if ( iQty == 2 )
+					if ( iQty >= 2 )
 					{
 						SKILL_TYPE iSkill = g_Cfg.FindSkillKey( ppArgs[0] );
 						if ( iSkill == SKILL_NONE )
 							return false;
-
-						sVal.FormatVal( Skill_UseQuick( iSkill, Exp_GetVal( ppArgs[1] )));
+						
+						sVal.FormatVal( Skill_UseQuick( iSkill, Exp_GetVal( ppArgs[1] ), true ,(Exp_GetVal(ppArgs[2]) != 0 ? false : true), (Exp_GetVal(ppArgs[3]) != 0 ? true : false)));
 						return true;
 					}
 				}
@@ -3473,15 +3473,15 @@ bool CChar::r_LoadVal( CScript & s )
 			{
 				if ( s.GetArgStr() )
 				{
-					tchar * ppArgs[2];
+					tchar * ppArgs[4];
 					int iQty = Str_ParseCmds(const_cast<tchar *>(s.GetArgStr()), ppArgs, CountOf( ppArgs ));
-					if ( iQty == 2 )
+					if ( iQty >= 2 )
 					{
 						SKILL_TYPE iSkill = g_Cfg.FindSkillKey( ppArgs[0] );
 						if ( iSkill == SKILL_NONE )
 							return false;
 
-						 Skill_UseQuick( iSkill, Exp_GetVal( ppArgs[1] ));
+						Skill_UseQuick( iSkill, Exp_GetVal( ppArgs[1] ), true, (Exp_GetVal(ppArgs[2]) != 0 ? false : true), (Exp_GetVal(ppArgs[3]) != 0 ? true : false));
 						return true;
 					}
 				}

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -857,7 +857,7 @@ public:
 
 	void Skill_SetBase( SKILL_TYPE skill, ushort uiValue );
     void Skill_AddBase( SKILL_TYPE skill, int iChange );
-	bool Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain = true, bool bUseBellCurve = true );
+	bool Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain = true, bool bUseBellCurve = true, bool bForceCheck = false);
 
 	bool Skill_CheckSuccess( SKILL_TYPE skill, int difficulty, bool bUseBellCurve = true ) const;
 	bool Skill_Wait( SKILL_TYPE skilltry );

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -508,7 +508,7 @@ bool CChar::Skill_CheckSuccess( SKILL_TYPE skill, int difficulty, bool bUseBellC
 	return ( iSuccessChance >= Calc_GetRandVal(1000) );
 }
 
-bool CChar::Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain, bool bUseBellCurve )
+bool CChar::Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain, bool bUseBellCurve, bool bForceCheck )
 {
 	ADDTOCALLSTACK("CChar::Skill_UseQuick");
 	// ARGS:
@@ -519,7 +519,7 @@ bool CChar::Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain,
 	// Use a skill instantly. No wait at all.
 	// No interference with other skills.
 
-	if (g_Cfg.IsSkillFlag(skill, SKF_SCRIPTED))
+	if (g_Cfg.IsSkillFlag(skill, SKF_SCRIPTED) && !bForceCheck)
 		return false;
 
 	int64 result = Skill_CheckSuccess( skill, (int)difficulty, bUseBellCurve );

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -1055,7 +1055,7 @@ bool CClient::Cmd_Skill_Tracking( uint track_sel, bool fExec )
 	ASSERT(m_pChar);
 	if ( track_sel == UINT32_MAX )
 	{
-		// Tacking (unlike other skills) is used during menu setup.
+		// Tracking (unlike other skills) is used during menu setup.
 		m_pChar->Skill_Cleanup();	// clean up current skill.
 
 		CMenuItem item[6];


### PR DESCRIPTION
…SKILLUSEQUICK character command:

 SKILLUSEQUICK "skillId", "difficulty", "linearcheck", "forcecheck"

 Linearcheck:
 This optional parameter when set to 1 will make Sphere performs a linear check instead of using the default Bell Curve formula.
 The linear check is usually used for combat checks (hitting, parrying, resisting spells) while the Bell curve check is usually used by almost all of the other skills.
 Take note that when using the linear check, the highest is the difficulty value the easier is to pass the test, while the opposite is true for a Bell curve check.

 Forcecheck:
 This optional paramter allows the execution of the Skill_UseQuick method by a skill with SKF_SCRIPTED flag.
 By default Sphere does not allow a skill with SKF_SCRIPTED flag to execute the Skill_UseQuick method, setting the value to 1 will allow the execution
 of the Skill_UseQuick method.

 Examples:
 skillusequick skill_appraise,75   //Make a quick check with item id skill with a difficulty of 75 and using the bell formula.
 skillusequick skill_appraise,<itemid>/10,1  //Make a quick check with the item id skill with a difficulty equal to the character itemid value and using the linear check formula.
 skillusequick skill_parrying,50,0,1  //Assuming that the parrying skill has the SKF_SCRIPTED flag, make a quick check with parrying skill,  using the Bell curve formula with a difficulty of 50 and forcing the execution of  the Skill_UseQuick method.

 Special Cases
 Sphere internally uses a quick check when certain actions are performed:

 Camping: Camping skill uses a quick check for activating up campfires.
 Mining:  Lingot smelting is handled by a quick check.
 Musicianship: Playing an instrument is handled by a quick check.
 Parrying: The success check for Parrying is handled by a quick check, remember that by adding the SKF_SCRIPTED flags to the Parrying skill will made you lose access to the @HitParry trigger.
 Repairing Items: Two quick checks are made, one uses the crafting skill from which the item is created by, the second uses the Arms Lore skill.
 Resisting Spells: A quick check is made when resisting a spell with SPELLFLAG_RESIST.
 Tinkering: Copying a key is performed by a Tinkering quick check.
 Training Dummies: All the Melee, Ranged and Pickpocket dummies uses a quick check.
 Tracking: Tracking uses a quick check when STARTING to track (the tracking menu is displayed and the quarry category is selected)