### PR TITLE
Possible Fix?  Items not buyable from Vendors.

### DIFF
--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -726,7 +726,7 @@ bool PacketVendorBuyReq::onReceive(NetState* net)
 		return true;
 	}
 
-    VendorItem items[MAX_ITEMS_CONT] = {};
+    VendorItem items[MAX_ITEMS_CONT] = {0};
     const uint uiCountFromPacket = (packetLength - 8u) / 7u;
 	uint itemCount = minimum(uiCountFromPacket, g_Cfg.m_iContainerMaxItems);
 


### PR DESCRIPTION
 It seems that struct items was not initialized? I don't know if it's the correct way, i just checked this:

http://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Initializing-Structure-Members