### PR TITLE
Updated custom multi AddStairs/RemoveItem

### DIFF
--- a/src/game/items/CItemMultiCustom.cpp
+++ b/src/game/items/CItemMultiCustom.cpp
@@ -720,6 +720,58 @@ void CItemMultiCustom::RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x,
     bool fComponentsChanged = false;
     auto& vectorComponents = m_designWorking.m_vectorComponents;
 	    
+	/*
+	if (fAllowRemoveWholeFloor && (uiPlaneAtZ > 1))
+	{
+		// If i'm removing a single floor tile and below there's a stair, this tile is invalid;
+		//  by removing this single invalid tile, the client actually removes the whole floor (even if it has different IDs), so we need to reflect that change here.
+		// It's not perfect though, because the client removes the whole floor if on the same row or column of the selected tile there's a stair below.
+		//  The way we are checking if we have a stair below doesn't work if the selected floor tile has below the lowest (lowest z) stair part.
+		bool fIsFloor = false;
+		for (size_t i = 0; i < uiCount; ++i)
+		{
+			if (pComponents[i]->m_isFloor)
+			{
+				fIsFloor = true;
+				break;
+			}
+		}
+
+		if (fIsFloor)
+		{
+			bool fStairsBelow = false;
+			Component* pComponentsStairs[INT8_MAX];
+			size_t uiCountStairs = GetComponentsAt(x, y, z - 1, pComponentsStairs, &m_designWorking);
+			if (uiCountStairs > 0)
+			{
+				for (size_t i = 0; i < uiCountStairs; ++i)
+				{
+					if (pComponentsStairs[i]->m_isStair)
+					{
+						fStairsBelow = true;
+						break;
+					}
+				}
+			}
+
+			if (fStairsBelow)
+			{
+				for (ComponentsContainer::iterator it = vectorComponents.begin(); it != vectorComponents.end(); )
+				{
+					Component* pComp = *it;
+					if ((pComp->m_isFloor) && (pComp->m_item.m_dz == z))
+					{
+						it = vectorComponents.erase(it);
+						fComponentsChanged = true;
+					}
+					else
+						++it;
+				}
+			}
+		}
+	}
+	*/
+
     bool fReplaceDirt = false;
     for (size_t i = 0; i < uiCount; ++i)
     {

--- a/src/game/items/CItemMultiCustom.cpp
+++ b/src/game/items/CItemMultiCustom.cpp
@@ -368,7 +368,7 @@ void CItemMultiCustom::CommitChanges(CClient * pClientSrc)
         pt.m_z += (char)((*i)->m_item.m_dz);
 
         pItem->m_uidLink = GetUID();
-        pItem->ClrAttr(ATTR_DECAY | ATTR_CAN_DECAY);
+        pItem->ClrAttr(ATTR_DECAY);
         pItem->SetAttr(ATTR_MOVE_NEVER);
         pItem->m_TagDefs.SetNum("FIXTURE", (int64)(GetUID()));
 
@@ -520,7 +520,7 @@ void CItemMultiCustom::AddItem(CClient * pClientSrc, ITEMID_TYPE id, short x, sh
                     continue;
 
                 const Component* pComp = pPrevComponents[i];
-                RemoveItem(nullptr, pComp->m_item.GetDispID(), pComp->m_item.m_dx, pComp->m_item.m_dy, (char)(pComp->m_item.m_dz), false);
+                RemoveItem(nullptr, pComp->m_item.GetDispID(), pComp->m_item.m_dx, pComp->m_item.m_dy, (char)(pComp->m_item.m_dz));
             }
         }
     }
@@ -577,7 +577,7 @@ void CItemMultiCustom::AddItem(CClient * pClientSrc, ITEMID_TYPE id, short x, sh
     }
 }
 
-void CItemMultiCustom::AddStairs(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z, short iStairID)
+void CItemMultiCustom::AddStairs(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z)
 {
     ADDTOCALLSTACK("CItemMultiCustom::AddStairs");
     // add a staircase to the building, the given ID must
@@ -613,8 +613,13 @@ void CItemMultiCustom::AddStairs(CClient * pClientSrc, ITEMID_TYPE id, short x, 
             z = 0;
     }
 
-    if (iStairID == -1)
-        iStairID = GetStairCount() + 1;
+	short iStairID = 0;
+	for (ComponentsContainer::iterator i = m_designWorking.m_vectorComponents.begin(); i != m_designWorking.m_vectorComponents.end(); ++i)
+	{
+		if ((*i)->m_isStair > iStairID)
+			iStairID = (*i)->m_isStair;
+	}
+	++iStairID;
 
     uint iQty = pMulti->GetItemCount();
     for (uint i = 0; i < iQty; ++i)
@@ -672,7 +677,7 @@ void CItemMultiCustom::AddRoof(CClient * pClientSrc, ITEMID_TYPE id, short x, sh
     AddItem(pClientSrc, id, x, y, z);
 }
 
-void CItemMultiCustom::RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z, bool fAllowRemoveWholeFloor)
+void CItemMultiCustom::RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z)
 {
     ADDTOCALLSTACK("CItemMultiCustom::RemoveItem");
     // remove the item that's found at given location
@@ -714,57 +719,7 @@ void CItemMultiCustom::RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x,
 
     bool fComponentsChanged = false;
     auto& vectorComponents = m_designWorking.m_vectorComponents;
-
-    if (fAllowRemoveWholeFloor && (uiPlaneAtZ > 1))
-    {
-        // If i'm removing a single floor tile and below there's a stair, this tile is invalid;
-        //  by removing this single invalid tile, the client actually removes the whole floor (even if it has different IDs), so we need to reflect that change here.
-        // It's not perfect though, because the client removes the whole floor if on the same row or column of the selected tile there's a stair below.
-        //  The way we are checking if we have a stair below doesn't work if the selected floor tile has below the lowest (lowest z) stair part.
-        bool fIsFloor = false;
-        for (size_t i = 0; i < uiCount; ++i)
-        {
-            if (pComponents[i]->m_isFloor)
-            {
-                fIsFloor = true;
-                break;
-            }
-        }
-
-        if (fIsFloor)
-        {
-            bool fStairsBelow = false;
-            Component* pComponentsStairs[INT8_MAX];
-            size_t uiCountStairs = GetComponentsAt(x, y, z - 1, pComponentsStairs, &m_designWorking);
-            if (uiCountStairs > 0)
-            {
-                for (size_t i = 0; i < uiCountStairs; ++i)
-                {
-                    if (pComponentsStairs[i]->m_isStair)
-                    {
-                        fStairsBelow = true;
-                        break;
-                    }
-                }
-            }
-
-            if (fStairsBelow)
-            {
-                for (ComponentsContainer::iterator it = vectorComponents.begin(); it != vectorComponents.end(); )
-                {
-                    Component* pComp = *it;
-                    if ((pComp->m_isFloor) && (pComp->m_item.m_dz == z))
-                    {
-                        it = vectorComponents.erase(it);
-                        fComponentsChanged = true;
-                    }
-                    else
-                        ++it;
-                }
-            }           
-        }
-    }
-    
+	    
     bool fReplaceDirt = false;
     for (size_t i = 0; i < uiCount; ++i)
     {
@@ -856,7 +811,7 @@ void CItemMultiCustom::RemoveRoof(CClient * pClientSrc, ITEMID_TYPE id, short x,
     if ((pItemBase->GetTFlags() & UFLAG4_ROOF) == 0)
         return;
 
-    RemoveItem(pClientSrc, id, x, y, z, false);
+    RemoveItem(pClientSrc, id, x, y, z);
 }
 
 void CItemMultiCustom::SendVersionTo(CClient * pClientSrc) const
@@ -1103,22 +1058,6 @@ uchar CItemMultiCustom::GetLevelCount()
         return 4;
 
     return 3;
-}
-
-short CItemMultiCustom::GetStairCount()
-{
-    ADDTOCALLSTACK("CItemMultiCustom::GetStairCount");
-    // find and return the highest stair id
-    short iCount = 0;
-    for (Component *pComp : m_designWorking.m_vectorComponents)
-    {
-        if (pComp->m_isStair == 0)
-            continue;
-
-        iCount = maximum(iCount, pComp->m_isStair);
-    }
-
-    return iCount;
 }
 
 size_t CItemMultiCustom::GetFixtureCount(DesignDetails * pDesign)
@@ -1572,8 +1511,7 @@ bool CItemMultiCustom::r_Verb(CScript & s, CTextConsole * pSrc) // Execute comma
                 id,
                 (Exp_GetSVal(ppArgs[1])),
                 (Exp_GetSVal(ppArgs[2])),
-                (Exp_GetCVal(ppArgs[3])),
-                (sm_mapValidItems.find(id) == sm_mapValidItems.end() ? 0 : -1));
+                (Exp_GetCVal(ppArgs[3])));
         }
         break;
 
@@ -1638,8 +1576,7 @@ bool CItemMultiCustom::r_Verb(CScript & s, CTextConsole * pSrc) // Execute comma
                 (ITEMID_TYPE)(Exp_GetVal(ppArgs[0])),
                 (Exp_GetSVal(ppArgs[1])),
                 (Exp_GetSVal(ppArgs[2])),
-                (Exp_GetCVal(ppArgs[3])),
-                false);
+                (Exp_GetCVal(ppArgs[3])));
         }
         break;
 

--- a/src/game/items/CItemMultiCustom.h
+++ b/src/game/items/CItemMultiCustom.h
@@ -100,9 +100,9 @@ public:
     void SwitchToLevel(CClient * pClientSrc, uchar iLevel);
     void CommitChanges(CClient * pClientSrc = nullptr);
     void AddItem(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z = INT8_MIN, short iStairID = 0);
-    void AddStairs(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z = INT8_MIN, short iStairID = -1);
+    void AddStairs(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z = INT8_MIN);
     void AddRoof(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z);
-    void RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z, bool fRemoveWholeFloor);
+    void RemoveItem(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z);
     bool RemoveStairs(Component * pStairComponent);
     void RemoveRoof(CClient * pClientSrc, ITEMID_TYPE id, short x, short y, char z);
     void SendVersionTo(CClient * pClientSrc) const;
@@ -118,7 +118,6 @@ public:
     size_t GetComponentsAt(short dx, short dy, char dz, Component ** pComponents, DesignDetails * pDesign = nullptr);
     int GetRevision(const CClient * pClientSrc = nullptr) const;
     uchar GetLevelCount();
-    short GetStairCount();
 
     static uchar GetPlane(char z);
     static uchar GetPlane(Component * pComponent);

--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -3688,7 +3688,7 @@ bool PacketHouseDesignDestroyItem::onReceive(CNetState* net)
 	skip(1); // 0x00
 	word z = (word)(readInt32());
 
-	house->RemoveItem(client, id, x, y, (char)z, true);
+	house->RemoveItem(client, id, x, y, (char)z);
 	return true;
 }
 


### PR DESCRIPTION
Modified the loop to search through iStairID in AddStairs (though using a short, no idea if that's the correct naming convention), now it is similar to what you can see in RemoveStairs. The last argument seems to be related to AddMulti but couldn't find a reason to keep it.

RemoveItem was modified to not remove the entire floor no matter what, client doesn't seem to like that, the server might remove the floor but you can commit and see the whole invalid items placed on it or whatever was removed from view by the server. I removed that bunch of code, maybe it would be the best to put it between some #ifdef or leave it commented.

Anyway, these are the differences I found between the 56d and X versions.
Tested on latest client (7.0.69?). Everything seems to work fine.